### PR TITLE
SGRAntlr Uniform .Net Target, Moved from 4.7.2 to 4.6.1

### DIFF
--- a/SGRAntlr/SGRAntlr.csproj
+++ b/SGRAntlr/SGRAntlr.csproj
@@ -10,11 +10,12 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SGRAntlrl</RootNamespace>
     <AssemblyName>SGRAntlrl</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -51,7 +52,6 @@
     <Compile Include="Grammars\Lexers\tomlLexer.g4.cs">
       <DependentUpon>tomlLexer.g4</DependentUpon>
     </Compile>
-    <Compile Include="Grammars\Listeners\TomlListener.cs" />
     <Compile Include="Grammars\Parsers\tomlParser.g4.cs">
       <DependentUpon>tomlParser.g4</DependentUpon>
     </Compile>
@@ -72,7 +72,9 @@
     </Antlr4>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Grammars\Listeners\" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SGRModules\SGRModules.csproj">
       <Project>{DDB0608E-3B8E-4136-A8D8-C4754C3AAF36}</Project>

--- a/ScriptGeneratorRedux/ViewModels/MainPageViewModel.cs
+++ b/ScriptGeneratorRedux/ViewModels/MainPageViewModel.cs
@@ -30,13 +30,13 @@ namespace ScriptGeneratorRedux.ViewModels
 
         private Boolean CanCopyContnetContent( object obj )
         {
-            return !( Core.DataContext is null ) &&
+            return ( Core.DataContext != null ) &&
                    !String.IsNullOrWhiteSpace( DocumentText ); ;
         }
 
         private Boolean CanExportContent( object obj )
         {
-            return !( Core.DataContext is null ) &&
+            return ( Core.DataContext != null ) &&
                    !String.IsNullOrWhiteSpace( DocumentText ); ;
         }
 
@@ -75,7 +75,7 @@ namespace ScriptGeneratorRedux.ViewModels
         {
             get
             {
-                return ( CurrentDocument is null ) ? null
+                return ( CurrentDocument == null ) ? null
                                                    : ( new TextRange( CurrentDocument.ContentStart, CurrentDocument.ContentEnd ) ).Text;
             }
         }


### PR DESCRIPTION
MainPageViewModel.cs Syntax change to enable compatability with older compiler and VS 2015